### PR TITLE
Se cambio código, se normalizaron los mensajes y se quitaron comentarios

### DIFF
--- a/Core/CoreHandler.cs
+++ b/Core/CoreHandler.cs
@@ -32,10 +32,6 @@ namespace P2P_UAQ_Server.Core
 		private TcpClient _client;
 		private Connection _newConnection = new Connection(); // Variable reutilizable para los usuarios conectados
 
-		//private Stream _stream;
-		//private StreamWriter _writer;
-		//private StreamReader _reader;
-
 		private bool _isRunning = false;
 
 		public event EventHandler<PrivateMessageReceivedEventArgs> PrivateMessageReceived;
@@ -52,12 +48,6 @@ namespace P2P_UAQ_Server.Core
 
         public event Action<string> ServerStatusUpdated;
 
-
-        // Invoker
-        //private void OnPrivateMessageReceived(PrivateMessageReceivedEventArgs e) => PrivateMessageReceived?.Invoke(this, e);
-
-        // Handler
-        //private void OnStatusUpdated(string message) => OnPrivateMessageReceived(new PrivateMessageReceivedEventArgs(message));
 
         //Para actualizar el status del server en el dashboard, esta se tiene que quedar
         public void OnStatusUpdated(string status)

--- a/Core/CoreHandler.cs
+++ b/Core/CoreHandler.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-//using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
 using System.IO;
@@ -68,7 +67,7 @@ namespace P2P_UAQ_Server.Core
 			_server = new TcpListener(IPAddress.Parse(_serverIP), _serverPort);
 			_server.Start(_maxConnections);
 
-			HandlerOnMessageReceived("Server listo y esperando en: " + _serverIP + ":" + _serverPort);
+			HandlerOnMessageReceived("Server listo y esperando en: [" + _serverIP + ":" + _serverPort + "]");
 
 			while (true)
 			{
@@ -85,7 +84,7 @@ namespace P2P_UAQ_Server.Core
 				_newConnection.IpAddress = newConnectionEndPoint.Address.ToString(); // ip
 				_newConnection.Port = newConnectionEndPoint.Port; // puerto
 
-				HandlerOnMessageReceived("En espera de aprovación de nombre: " + _newConnection.IpAddress + ":" + _newConnection.Port);
+				HandlerOnMessageReceived("En espera de aprovación de nombre: [" + _newConnection.IpAddress + ":" + _newConnection.Port+"]");
 
 				// confirmamos el nombre
 
@@ -95,11 +94,11 @@ namespace P2P_UAQ_Server.Core
 
 				_newConnection.Nickname = convertedData!.Nickname;
 
-				HandlerOnMessageReceived("Mensaje recibido");
+				HandlerOnMessageReceived("Mensaje con datos recibido: [" + _newConnection.IpAddress + ":" + _newConnection.Port + "]");
 
 				if (message.Type == MessageType.UserConnected)
 				{
-					var existingConnection = _connections.FindAll(c => c.Nickname == _newConnection.Nickname && c.IpAddress == _newConnection.IpAddress && c.Port == _newConnection.Port);
+					var existingConnection = _connections.FindAll(c => c.Nickname == _newConnection.Nickname);
 
 					if (existingConnection.Count == 0)
 					{
@@ -112,7 +111,7 @@ namespace P2P_UAQ_Server.Core
 
 						_connections.Add(_newConnection);
 
-						HandlerOnMessageReceived("Conexión agregada" + _newConnection.IpAddress + "" + _newConnection.Port + " y lista enviada a todos");
+						HandlerOnMessageReceived("Conexión agregada y lista enviada a todos: [" + _newConnection.Nickname + ":" + _newConnection.IpAddress + ":" + _newConnection.Port + "]");
 
 						foreach (Connection c in _connections)
 						{
@@ -144,7 +143,7 @@ namespace P2P_UAQ_Server.Core
 						_newConnection.StreamWriter.WriteLine(messageJson);
 						_newConnection.StreamWriter.Flush();
 
-						HandlerOnMessageReceived("Conexión rechazada: " + _newConnection.IpAddress + ":" + _newConnection.Port);
+						HandlerOnMessageReceived("Conexión rechazada: [" + _newConnection.IpAddress + ":" + _newConnection.Port + "]");
 					}
 				}
 
@@ -171,7 +170,7 @@ namespace P2P_UAQ_Server.Core
                         _connections.RemoveAll(c => c.Nickname == connection.Nickname && c.IpAddress == connection.IpAddress && c.Port == connection.Port);
                         SendDisconnectedUserToAll(connection);
 
-                        HandlerOnMessageReceived("User removed and sent: " + connection.Nickname + ":" + connection.IpAddress + ":" + connection.Port);
+                        HandlerOnMessageReceived("Usuario desconectado y todos alertados: [" + connection.Nickname + ":" + connection.IpAddress + ":" + connection.Port + "]");
                         connectionOpen = false;
                     }
                 }
@@ -181,7 +180,6 @@ namespace P2P_UAQ_Server.Core
 				}
             }
         }
-        // ****
 
         public void SendConnectionListToAll(Connection receiver, Connection connection)
         {
@@ -224,7 +222,7 @@ namespace P2P_UAQ_Server.Core
                 _server.Stop();
                 _isRunning = false;
             }
-			HandlerOnMessageReceived("Servidor cerrado");
+			HandlerOnMessageReceived("Servidor cerrado.");
         }
 
 

--- a/Core/CoreHandler.cs
+++ b/Core/CoreHandler.cs
@@ -24,7 +24,7 @@ namespace P2P_UAQ_Server.Core
         private readonly static CoreHandler _instance = new CoreHandler();
 		private string _serverIP;
 		private int _serverPort;
-		private string _maxConnections;
+		private int _maxConnections;
 		private TcpListener _server;
 		private List<Connection> _connections = new List<Connection>();
 
@@ -72,11 +72,11 @@ namespace P2P_UAQ_Server.Core
 		{
 			_serverIP = ip;
 			_serverPort = port;
-			_maxConnections = maxConnections;
+			_maxConnections = int.Parse(maxConnections);
 
 
 			_server = new TcpListener(IPAddress.Parse(_serverIP), _serverPort);
-			_server.Start(int.Parse(maxConnections));
+			_server.Start(_maxConnections);
 
 			HandlerOnMessageReceived("Server listo y esperando en: " + _serverIP + ":" + _serverPort);
 
@@ -105,7 +105,7 @@ namespace P2P_UAQ_Server.Core
 
 				_newConnection.Nickname = convertedData!.Nickname;
 
-				HandlerOnMessageReceived("mensaje recibido");
+				HandlerOnMessageReceived("Mensaje recibido");
 
 				if (message.Type == MessageType.UserConnected)
 				{
@@ -177,17 +177,17 @@ namespace P2P_UAQ_Server.Core
 
                     if (message.Type == MessageType.UserDisconnected)
                     {
-                       
+                        // disconnected user
+                        _connections.RemoveAll(c => c.Nickname == connection.Nickname && c.IpAddress == connection.IpAddress && c.Port == connection.Port);
+                        SendDisconnectedUserToAll(connection);
+
+                        HandlerOnMessageReceived("User removed and sent: " + connection.Nickname + ":" + connection.IpAddress + ":" + connection.Port);
+                        connectionOpen = false;
                     }
                 }
                 catch
                 {
-					// disconnected user
-					_connections.RemoveAll(c => c.Nickname == connection.Nickname && c.IpAddress == connection.IpAddress && c.Port == connection.Port);
-					SendDisconnectedUserToAll(connection);
-
-					HandlerOnMessageReceived("User removed and sent: " + connection.Nickname + ":" + connection.IpAddress + ":" + connection.Port);
-					connectionOpen = false;
+					
 				}
             }
         }


### PR DESCRIPTION
Se cambio código en el serviror. _maxConnections no era usada y era string, se cambió a int para usarse en start() del servidor. Se puso código dentro del try catch del ListenToConnection(), el código estaba en el catch y no en el try. Se cambió la condición de la revisión de los datos de usuario.
Los mensajes ahora tienen un formato estandar y un  idioma (español)
Se quitó código sin usar que estaba comentado